### PR TITLE
fix vless reality parsing

### DIFF
--- a/model/proxy_vmess.go
+++ b/model/proxy_vmess.go
@@ -16,8 +16,8 @@ type GrpcOptions struct {
 }
 
 type RealityOptions struct {
-	PublicKey string `proxy:"public-key"`
-	ShortID   string `proxy:"short-id"`
+	PublicKey string `yaml:"public-key"`
+	ShortID   string `yaml:"short-id,omitempty"`
 }
 
 type WSOptions struct {

--- a/parser/vless.go
+++ b/parser/vless.go
@@ -36,17 +36,17 @@ func ParseVless(proxy string) (model.Proxy, error) {
 	}
 	// 返回结果
 	result := model.Proxy{
-		Type:        "vless",
-		Server:      strings.TrimSpace(serverAndPort[0]),
-		Port:        port,
-		UUID:        strings.TrimSpace(parts[0]),
-		UDP:         true,
-		Sni:         params.Get("sni"),
-		Network:     params.Get("type"),
-		TLS:         params.Get("security") == "tls",
-		Flow:        params.Get("flow"),
-		Fingerprint: params.Get("fp"),
-		Servername:  params.Get("sni"),
+		Type:              "vless",
+		Server:            strings.TrimSpace(serverAndPort[0]),
+		Port:              port,
+		UUID:              strings.TrimSpace(parts[0]),
+		UDP:               true,
+		Sni:               params.Get("sni"),
+		Network:           params.Get("type"),
+		TLS:               params.Get("security") == "reality",
+		Flow:              params.Get("flow"),
+		ClientFingerprint: params.Get("fp"),
+		Servername:        params.Get("sni"),
 		RealityOpts: model.RealityOptions{
 			PublicKey: params.Get("pbk"),
 		},


### PR DESCRIPTION
This PR fix reality parsing, before it, the typical config seen by ClashMeta is:
```yaml
proxies:
    - type: vless
      name: some-proxy
      server: xx.xx.xx.xx
      port: 34544
      uuid: dd6cff67-5e50-4928-94ab-38b6f722553d
      flow: xtls-rprx-vision
      udp: true
      network: tcp
      reality-opts:
        publickey: xxxx
        shortid: ""
      fingerprint: chrome
      servername: blog.api.www.cloudflare.com
```
after:
```yaml
proxies:
    - type: vless
      name: some-proxy
      server: xx.xx.xx.xx
      port: 34544
      uuid: dd6cff67-5e50-4928-94ab-38b6f722553d
      flow: xtls-rprx-vision
      tls: true # tls should be true when security == 'reality'
      udp: true
      network: tcp
      reality-opts:
        public-key: xxxx # it should be public-key instead of publickey, the '-' is necessary
        short-id: "some id if not empty" # '-' is necessary 
      client-fingerprint: chrome # should be client-fingerprint instead of fingerprint
      servername: blog.api.www.cloudflare.com
```

The fixed config is tested in ClashX Meta v1.3.10 with meta core v.1.18.1
