### PR TITLE
🔧  customize HTTP user-agent for fetching subscription from API.

### DIFF
--- a/api/handler/default.go
+++ b/api/handler/default.go
@@ -32,7 +32,7 @@ func BuildSub(clashType model.ClashType, query validator.SubValidator, template 
 		template = query.Template
 	}
 	if strings.HasPrefix(template, "http") {
-		templateBytes, err = common.LoadSubscription(template, query.Refresh)
+		templateBytes, err = common.LoadSubscription(template, query.Refresh, query.UserAgent)
 		if err != nil {
 			logger.Logger.Debug(
 				"load template failed", zap.String("template", template), zap.Error(err),
@@ -61,7 +61,7 @@ func BuildSub(clashType model.ClashType, query validator.SubValidator, template 
 	var proxyList []model.Proxy
 	// 加载订阅
 	for i := range query.Subs {
-		data, err := common.LoadSubscription(query.Subs[i], query.Refresh)
+		data, err := common.LoadSubscription(query.Subs[i], query.Refresh, query.UserAgent)
 		subName := ""
 		if strings.Contains(query.Subs[i], "#") {
 			subName = query.Subs[i][strings.LastIndex(query.Subs[i], "#")+1:]

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -75,6 +75,12 @@
             <label for="proxy">节点分享链接:</label>
             <textarea class="form-control" id="proxy" name="proxy" placeholder="每行输入一个节点分享链接" rows="5"></textarea>
         </div>
+        <!-- User Agent -->
+        <div class="form-group mb-3">
+            <label for="user-agent">ua标识:</label>
+            <textarea class="form-control" id="user-agent" name="user-agent"
+                placeholder="用于获取订阅的http请求中的user-agent标识(可选)" rows="1"></textarea>
+        </div>
         <!-- Refresh -->
         <div class="form-check mb-3">
             <input class="form-check-input" id="refresh" name="refresh" type="checkbox" />
@@ -172,4 +178,5 @@
     </div>
 </body>
 <script src="./static/index.js"></script>
+
 </html>

--- a/api/static/index.js
+++ b/api/static/index.js
@@ -66,6 +66,11 @@ function generateURI() {
     // alert("订阅链接和节点分享链接不能同时为空！");
     return "";
   }
+
+  // 获取订阅user-agent标识
+  const userAgent = document.getElementById("user-agent").value;
+  queryParams.push(`userAgent=${userAgent}`)
+
   // 获取复选框的值
   const refresh = document.getElementById("refresh").checked;
   queryParams.push(`refresh=${refresh ? "true" : "false"}`);

--- a/common/sub.go
+++ b/common/sub.go
@@ -16,9 +16,9 @@ import (
 var subsDir = "subs"
 var fileLock sync.RWMutex
 
-func LoadSubscription(url string, refresh bool) ([]byte, error) {
+func LoadSubscription(url string, refresh bool, userAgent string) ([]byte, error) {
 	if refresh {
-		return FetchSubscriptionFromAPI(url)
+		return FetchSubscriptionFromAPI(url, userAgent)
 	}
 	hash := sha256.Sum224([]byte(url))
 	fileName := filepath.Join(subsDir, hex.EncodeToString(hash[:]))
@@ -27,7 +27,7 @@ func LoadSubscription(url string, refresh bool) ([]byte, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		return FetchSubscriptionFromAPI(url)
+		return FetchSubscriptionFromAPI(url, userAgent)
 	}
 	lastGetTime := stat.ModTime().Unix() // 单位是秒
 	if lastGetTime+config.Default.CacheExpire > time.Now().Unix() {
@@ -48,13 +48,13 @@ func LoadSubscription(url string, refresh bool) ([]byte, error) {
 		}
 		return subContent, nil
 	}
-	return FetchSubscriptionFromAPI(url)
+	return FetchSubscriptionFromAPI(url, userAgent)
 }
 
-func FetchSubscriptionFromAPI(url string) ([]byte, error) {
+func FetchSubscriptionFromAPI(url string, userAgent string) ([]byte, error) {
 	hash := sha256.Sum224([]byte(url))
 	fileName := filepath.Join(subsDir, hex.EncodeToString(hash[:]))
-	resp, err := Get(url)
+	resp, err := Get(url, WithUserAgent(userAgent))
 	if err != nil {
 		return nil, err
 	}

--- a/validator/sub.go
+++ b/validator/sub.go
@@ -31,6 +31,7 @@ type SubValidator struct {
 	ReplaceTo           []string             `form:"-" binding:""`
 	NodeListMode        bool                 `form:"nodeList,default=false" binding:""`
 	IgnoreCountryGrooup bool                 `form:"ignoreCountryGroup,default=false" binding:""`
+	UserAgent           string               `form:"userAgent" binding:""`
 }
 
 type RuleProviderStruct struct {


### PR DESCRIPTION
- 有的订阅根据user-agent判断客户端类型：比如，有的机场可能判断user-agent是否包含clash字段来判断该客户端是否是clash

- 这种情况下，默认user-agent无法返回正确的配置文件，需要手动设置user-agent返回正确的配置文件