### PR TITLE
:sparkles: 增加socks5协议支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - Trojan
   - Hysteria （Clash.Meta）
   - Hysteria2 （Clash.Meta）
+  - Socks5
 
 ## 使用
 

--- a/common/proxy.go
+++ b/common/proxy.go
@@ -127,6 +127,9 @@ func ParseProxy(proxies ...string) []model.Proxy {
 			if strings.HasPrefix(proxy, constant.HysteriaPrefix) {
 				proxyItem, err = parser.ParseHysteria(proxy)
 			}
+			if strings.HasPrefix(proxy, constant.SocksPrefix) {
+				proxyItem, err = parser.ParseSocks(proxy)
+			}
 			if err == nil {
 				result = append(result, proxyItem)
 			} else {

--- a/constant/prefix.go
+++ b/constant/prefix.go
@@ -9,4 +9,5 @@ const (
 	TrojanPrefix       string = "trojan://"
 	VLESSPrefix        string = "vless://"
 	VMessPrefix        string = "vmess://"
+	SocksPrefix        string = "socks"
 )

--- a/model/clash.go
+++ b/model/clash.go
@@ -14,6 +14,7 @@ func GetSupportProxyTypes(clashType ClashType) map[string]bool {
 			"ssr":    true,
 			"vmess":  true,
 			"trojan": true,
+			"socks5": true,
 		}
 	}
 	if clashType == ClashMeta {
@@ -25,6 +26,7 @@ func GetSupportProxyTypes(clashType ClashType) map[string]bool {
 			"vless":     true,
 			"hysteria":  true,
 			"hysteria2": true,
+			"socks5":    true,
 		}
 	}
 	return nil

--- a/model/proxy.go
+++ b/model/proxy.go
@@ -10,6 +10,7 @@ type Proxy struct {
 	Port                int                   `yaml:"port,omitempty"`
 	Type                string                `yaml:"type,omitempty"`
 	Cipher              string                `yaml:"cipher,omitempty"`
+	Username            string                `yaml:"username,omitempty"`
 	Password            string                `yaml:"password,omitempty"`
 	UDP                 bool                  `yaml:"udp,omitempty"`
 	UUID                string                `yaml:"uuid,omitempty"`

--- a/parser/socks.go
+++ b/parser/socks.go
@@ -1,0 +1,79 @@
+package parser
+
+import (
+	"fmt"
+	"github.com/nitezs/sub2clash/constant"
+	"github.com/nitezs/sub2clash/model"
+	"net/url"
+	"strings"
+)
+
+func ParseSocks(proxy string) (model.Proxy, error) {
+	if !strings.HasPrefix(proxy, constant.SocksPrefix) {
+		return model.Proxy{}, &ParseError{Type: ErrInvalidPrefix, Raw: proxy}
+	}
+	link, err := url.Parse(proxy)
+	if err != nil {
+		return model.Proxy{}, &ParseError{
+			Type:    ErrInvalidStruct,
+			Message: "url parse error",
+			Raw:     proxy,
+		}
+	}
+	server := link.Hostname()
+	if server == "" {
+		return model.Proxy{}, &ParseError{
+			Type:    ErrInvalidStruct,
+			Message: "missing server host",
+			Raw:     proxy,
+		}
+	}
+	portStr := link.Port()
+	if portStr == "" {
+		return model.Proxy{}, &ParseError{
+			Type:    ErrInvalidStruct,
+			Message: "missing server port",
+			Raw:     proxy,
+		}
+	}
+	port, err := ParsePort(portStr)
+	if err != nil {
+		return model.Proxy{}, &ParseError{
+			Type: ErrInvalidPort,
+			Raw:  portStr,
+		}
+	}
+
+	remarks := link.Fragment
+	if remarks == "" {
+		remarks = fmt.Sprintf("%s:%s", server, portStr)
+	}
+	remarks = strings.TrimSpace(remarks)
+
+	encodeStr := link.User.Username()
+	var username, password string
+	if encodeStr != "" {
+		decodeStr, err := DecodeBase64(encodeStr)
+		splitStr := strings.Split(decodeStr, ":")
+		if err != nil {
+			return model.Proxy{}, &ParseError{
+				Type:    ErrInvalidStruct,
+				Message: "url parse error",
+				Raw:     proxy,
+			}
+		}
+		username = splitStr[0]
+		if len(splitStr) == 2 {
+			password = splitStr[1]
+		}
+	}
+	return model.Proxy{
+		Type:     "socks5",
+		Name:     remarks,
+		Server:   server,
+		Port:     port,
+		Username: username,
+		Password: password,
+	}, nil
+
+}


### PR DESCRIPTION
增加了对socks5协议的支持，使用v2ray格式的socks5链接,
即:`socks://base64(username:password)@server:port#remark`
下面是几个测试链接
```
socks://YWRtaW46@127.0.0.1:7890#test-1
socks://YWRtaW46MTIz@127.0.0.1:7891#test-2
socks://Og==@127.0.0.1:7892#test-3
socks://127.0.0.1:7893#test-4
```
转换后的节点为
```
proxies:
    - name: test-1
      server: 127.0.0.1
      port: 7890
      type: socks5
      username: admin
    - name: test-2
      server: 127.0.0.1
      port: 7891
      type: socks5
      username: admin
      password: "123"
    - name: test-3
      server: 127.0.0.1
      port: 7892
      type: socks5
    - name: test-4
      server: 127.0.0.1
      port: 7893
      type: socks5